### PR TITLE
ci: skip 'no-commit-to-branch' pre-commit hook in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   pre_commit:
     runs-on: ubuntu-latest
+    env:
+      SKIP: ${{ github.ref == 'refs/heads/master' && 'no-commit-to-branch' || '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
GitHub config provides sufficient protection from committing to main. This hook failed on merge commits merging a pull request to main.