### PR TITLE
ci: add a step to containerise the app and push to GitHub's registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.github/
+
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.venv/
+
+*.yaml
+*.MD
+LICENSE
+.editorconfig
+
+tests/

--- a/.github/actions/containerise/action.yaml
+++ b/.github/actions/containerise/action.yaml
@@ -1,0 +1,59 @@
+# Re-usable steps for a GitHub Action that Dockerises the app
+# and pushes the container to the GitHub Container Registry.
+#
+# Usage:
+#   ```
+#   steps:
+#     - uses: ./.github/actions/containerise
+#         with:
+#           registry: ${{ env.REGISTRY }}
+#           username: ${{ env.username }}
+#           password: ${{ env.password }}
+#           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+#   ```
+#
+# (c) 2024 Alberto Morón Hernández
+name: 'containerise'
+description: 'Run all pre-commit hooks against the codebase'
+
+inputs:
+  registry:
+    description: 'Container registry'
+    required: true
+  username:
+    description: 'Container registry username'
+    required: true
+  password:
+    description: 'Container registry password'
+    required: true
+  platforms:
+    description: 'Comma-separated list of architectures to target'
+    required: false
+    default: linux/amd64,linux/arm64  # GCP Cloud Run, Apple Silicon
+  provenance:
+    description: 'Whether to generate provenance attestation for the build'
+    required: false
+    # must be false for multi-arch builds with recent versions of 'build-push-action'
+    # see https://github.com/docker/build-push-action/issues/773
+    default: 'false'
+  tags:
+    description: 'List of tags to assign to the image'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+    - uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: ${{ inputs.platforms }}
+        push: true
+        provenance: ${{ inputs.provenance }}
+        tags: ${{ inputs.tags }}

--- a/.github/actions/pre-commit/action.yaml
+++ b/.github/actions/pre-commit/action.yaml
@@ -1,0 +1,22 @@
+# Re-usable steps for a GitHub Action that runs all pre-commit hooks.
+#
+# Usage:
+#   ```
+#   steps:
+#     - uses: ./.github/actions/pre-commit
+#   ```
+#
+# (c) 2024 Alberto Morón Hernández
+name: 'pre-commit'
+description: 'Run all pre-commit hooks against the codebase'
+
+runs:
+  using: 'composite'
+  steps:
+    # global shared state: modifies `env` inside this action AND outside in the caller.
+    - run: |
+        # Skip hook since it causes issues when merging PRs, and already enforced by GitHub config.
+        echo "SKIP=no-commit-to-branch" >> $GITHUB_ENV
+      shell: bash
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -1,0 +1,20 @@
+# Re-usable steps for a GitHub Action that ...
+#
+# Usage:
+#   ```
+#   steps:
+#     - uses: ./.github/actions/FOO
+#   ```
+#
+# (c) 2024 Alberto Morón Hernández
+name: 'test'
+description: 'Run unit and integration tests'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: ./.github/actions/uv
+    - run: |
+        make install-deps-test
+        make test
+      shell: bash

--- a/.github/actions/uv/action.yaml
+++ b/.github/actions/uv/action.yaml
@@ -8,7 +8,7 @@
 #
 # (c) 2024 Alberto Morón Hernández
 name: 'Install uv'
-description: 'Check out, set up Python, install uv'
+description: 'Check out project code, set up Python, install uv'
 
 runs:
   using: 'composite'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   pre_commit:
     runs-on: ubuntu-latest
@@ -29,3 +32,27 @@ jobs:
         - run: |
             make install-deps-test
             make test
+
+  containerise:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - run: |
+            echo "GIT_REF=${{ github.event.pull_request && github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+            echo "REPO_NAME=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
+          shell: bash
+        - uses: docker/setup-buildx-action@v3
+        - uses: docker/login-action@v3
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ github.token }}
+        - uses: docker/build-push-action@v5
+          with:
+            context: .
+            file: ./Dockerfile
+            platforms: linux/amd64,linux/arm64  # GCP Cloud Run, Apple Silicon
+            push: true
+            tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}/${{ env.GIT_REF }}:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,12 @@
 # DepositDuck Continuous Integration pipeline
+# Runs when a Pull Request is merged into the 'main' branch.
 #
 # (c) 2024 Alberto Morón Hernández
 name: CI
 
 on:
   pull_request:
-  push:
+    types: [closed]
     branches:
       - main
 
@@ -15,44 +16,32 @@ env:
 jobs:
   pre_commit:
     runs-on: ubuntu-latest
-    env:
-      SKIP: "no-commit-to-branch"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v3.0.1
+      - uses: ./.github/actions/pre-commit
 
   test:
     needs:
       - pre_commit
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: ./.github/actions/uv
-        - run: |
-            make install-deps-test
-            make test
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test
 
   containerise:
     needs:
       - test
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - run: |
-            echo "GIT_REF=${{ github.event.pull_request && github.head_ref || github.ref_name }}" >> $GITHUB_ENV
-            echo "REPO_NAME=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
-          shell: bash
-        - uses: docker/setup-buildx-action@v3
-        - uses: docker/login-action@v3
-          with:
-            registry: ${{ env.REGISTRY }}
-            username: ${{ github.actor }}
-            password: ${{ github.token }}
-        - uses: docker/build-push-action@v5
-          with:
-            context: .
-            file: ./Dockerfile
-            platforms: linux/amd64,linux/arm64  # GCP Cloud Run, Apple Silicon
-            push: true
-            tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}/${{ env.GIT_REF }}:latest
+      - uses: actions/checkout@v4
+      - run: |
+          # assign the branch name to GIT_REF & lowercase repository name to REPO_NAME
+          echo "GIT_REF=${{ github.event.pull_request && github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+          echo "REPO_NAME=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
+        shell: bash
+      - uses: ./.github/actions/containerise
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}/${{ env.GIT_REF }}:latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,28 @@
+# DepositDuck Continuous Integration pipeline
+# Runs when a commit on a feature branch is pushed up to GitHub.
+#
+# (c) 2024 Alberto Morón Hernández
+name: PR
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches-ignore:
+      - main
+
+jobs:
+  pre_commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pre-commit
+
+  test:
+    needs:
+      - pre_commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A htmx frontend.
 - Bootstrap 5 to style the frontend.
 - A dependable that provides access to `structlog` in the FastAPI application.
-- A CI pipeline using GitHub actions. Runs pre-commit hooks and tests.
-- SAST scanning by adding `bandit` as a pre-commit hook.
+- A CI pipeline using GitHub actions. Runs pre-commit hooks and tests for each commit. When
+  PRs are merged, in addition to these checks a pipeline Dockerises the app and pushes it
+  to the GitHub Container Registry.
+- SAST scanning via `bandit` as a pre-commit hook.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerfile used to containerise the app in the CI pipeline.
+#
+# (c) 2024 Alberto Morón Hernández
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements/base.txt requirements/base.txt
+
+RUN pip install uv
+RUN uv pip install --system --no-cache-dir -r requirements/base.txt
+
+COPY . .
+
+CMD ["uvicorn", "depositduck.main:webapp", "--host", "0.0.0.0", "--port", "80"]

--- a/README.md
+++ b/README.md
@@ -113,8 +113,37 @@ make test
 
 ##  Continuous Integration
 
-A Continuous Integration pipeline runs via GitHub Actions on push.  
-This pipeline is defined by the YAML in the `.github/workflows/` directory.
+Continuous Integration pipelines run via GitHub Actions on push.  
+Pipelines are defined by YAML files in the `.github/workflows/` directory.
+There are two workflows:
+
+- When a commit on a feature branch is pushed up to GitHub - `pr.yaml`
+- When a Pull Request is merged into the 'main' branch - `ci.yaml`
+
+They both run pre-commit hooks and tests against the codebase. `ci.yaml` additionally
+Dockerises the app and pushes the image to the GitHub Container Registry.  
+The build artefact is a multi-arch Docker image to ensure compatibility with both
+Apple Silicon (ARM64) and GCP Cloud Run (x86_64).
+
+To run a Docker image locally:
+
+1. Visit [github.com/settings/tokens/new?scopes=write:packages](https://github.com/settings/tokens/new?scopes=write:packages)
+1. Select all relevant `packages` scopes and create a new Personal Access Token (PAT).
+1. Save the PAT as a environment variable: `export GHCR_PAT=YOUR_TOKEN`
+
+```sh
+# 4. Sign in to the Container Registry:
+echo $GHCR_PAT | docker login ghcr.io -u USERNAME --password-stdin
+
+# 5. Pull the latest image
+docker pull ghcr.io/albertomh/depositduck/main:latest
+
+# 6. Run the webapp on port 80
+docker run -d -p 80:80 --name depositduck_web depositduck
+
+# 7. Clean up
+docker stop depositduck_web && docker rm depositduck_web
+```
 
 ## Deploy
 


### PR DESCRIPTION
- Add a step to containerise the app and push to GitHub's registry.
- Refactor CI jobs into Actions to re-use across workflows
- Document CI pipelines & fetching images from GHCR