### PR TITLE
ci: tag Docker images with the name of the base branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          # assign the branch name to GIT_REF & lowercase repository name to REPO_NAME
-          echo "GIT_REF=${{ github.event.pull_request && github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+          # assign the base branch name to GIT_REF & lowercase repository name to REPO_NAME
+          echo "GIT_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
           echo "REPO_NAME=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
         shell: bash
       - uses: ./.github/actions/containerise


### PR DESCRIPTION
As part of the 'CI' workflow, tag the Docker images uploaded to GHCR with the name of the base branch in the PR that triggered the build (will be 'main' branch).